### PR TITLE
GH-35: Updated to use kettle@2.1.0 (resolves #35).

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "dependencies": {
         "ajv": "6.12.3",
         "fluid-binder": "1.1.2",
-        "fluid-express": "1.0.18-dev.20210121T091003Z.bfaa948.GH-49",
-        "fluid-handlebars": "2.1.5-dev.20210121T093854Z.653733b.GH-39",
+        "fluid-express": "1.0.18",
+        "fluid-handlebars": "2.1.5",
         "infusion": "3.0.0-dev.20210120T204128Z.6e4be079f.FLUID-6580",
         "kettle": "2.1.0"
     },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "dependencies": {
         "ajv": "6.12.3",
         "fluid-binder": "1.1.2",
-        "fluid-express": "1.0.17",
-        "fluid-handlebars": "2.1.4",
-        "infusion": "3.0.0-dev.20210114T215306Z.2b1fe9609.FLUID-6580",
-        "kettle": "1.15.0"
+        "fluid-express": "1.0.18-dev.20210121T091003Z.bfaa948.GH-49",
+        "fluid-handlebars": "2.1.5-dev.20210121T093854Z.653733b.GH-39",
+        "infusion": "3.0.0-dev.20210120T204128Z.6e4be079f.FLUID-6580",
+        "kettle": "2.1.0"
     },
     "devDependencies": {
         "eslint": "7.18.0",

--- a/tests/js/node/kettle-validation-tests.js
+++ b/tests/js/node/kettle-validation-tests.js
@@ -161,59 +161,59 @@ fluid.defaults("fluid.tests.schema.kettle.caseHolder", {
     ],
     components: {
         validBodyRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "POST",
-                path: "/gated/body"
+                endpoint: "gated/body"
             }
         },
         invalidBodyRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "POST",
-                path: "/gated/body"
+                endpoint: "gated/body"
             }
         },
         validParamsRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "GET",
-                path: "/gated/params/good"
+                endpoint: "gated/params/good"
             }
         },
         invalidParamsRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "GET",
-                path: "/gated/params/bad"
+                endpoint: "gated/params/bad"
             }
         },
         validQueryRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "GET",
-                path: "/gated/query?hasQueryContent=good"
+                endpoint: "gated/query?hasQueryContent=good"
             }
         },
         invalidQueryRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "GET",
-                path: "/gated/query?hasQueryContent=bad"
+                endpoint: "gated/query?hasQueryContent=bad"
             }
         },
         validCombinedRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "POST",
-                path: "/gated/combined/good?hasQueryContent=good"
+                endpoint: "gated/combined/good?hasQueryContent=good"
             }
         },
         invalidCombinedRequest: {
-            type: "fluid.test.schema.kettle.request",
+            type: "fluid.test.schema.request",
             options: {
                 method: "POST",
-                path: "/gated/combined/bad?hasQueryContent=bad"
+                endpoint: "gated/combined/bad?hasQueryContent=bad"
             }
         }
     }

--- a/tests/js/node/lib/fixtures.js
+++ b/tests/js/node/lib/fixtures.js
@@ -139,7 +139,7 @@ fluid.defaults("fluid.test.schema.caseHolder", {
 fluid.defaults("fluid.test.schema.request", {
     gradeNames: ["kettle.test.request.http"],
     port: "{testEnvironment}.options.port",
-    path: {
+    url: {
         expander: {
             funcName: "fluid.stringTemplate",
             args:     ["http://localhost:%port/%endpoint", { port: "{testEnvironment}.options.port", endpoint: "{that}.options.endpoint"}]

--- a/tests/js/node/lib/kettle-test-fixtures.js
+++ b/tests/js/node/lib/kettle-test-fixtures.js
@@ -192,11 +192,3 @@ fluid.defaults("fluid.test.schema.kettle.app", {
         }
     }
 });
-
-fluid.defaults("fluid.test.schema.kettle.request", {
-    gradeNames: ["kettle.test.request.http"],
-    headers: {
-        accept: "application/json"
-    },
-    port:  "{testEnvironment}.options.port"
-});

--- a/tests/js/node/middleware-express-tests.js
+++ b/tests/js/node/middleware-express-tests.js
@@ -19,6 +19,8 @@ kettle.loadTestingSupport();
 
 require("../../../");
 
+require("./lib/fixtures");
+
 fluid.registerNamespace("fluid.tests.schema.middleware.express.caseHolder");
 fluid.tests.schema.middleware.express.caseHolder.examineResponse = function (response, body, shouldBeValid) {
     if (shouldBeValid) {
@@ -37,17 +39,16 @@ fluid.tests.schema.middleware.express.caseHolder.examineResponse = function (res
 };
 
 fluid.defaults("fluid.tests.schema.middleware.request", {
-    gradeNames: ["kettle.test.request.http"],
-    path:       {
+    gradeNames: ["fluid.test.schema.request"],
+    endpoint: {
         expander: {
             funcName: "fluid.stringTemplate",
-            args: ["/gated/%method", { method: "{that}.options.method"}]
+            args: ["gated/%method", { method: "{that}.options.method"}]
         }
     },
     headers: {
         accept: "application/json"
-    },
-    port:       "{testEnvironment}.options.port"
+    }
 });
 
 fluid.defaults("fluid.tests.schema.middleware.request.post", {
@@ -220,7 +221,7 @@ fluid.defaults("fluid.tests.schema.middleware.express.caseHolder", {
         goodJsonGetRequest: {
             type: "fluid.tests.schema.middleware.request.get",
             options: {
-                path: "/gated/get?shallowlyRequired=true"
+                endpoint: "gated/get?shallowlyRequired=true"
             }
         },
         emptyPostRequest: {

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -42,14 +42,12 @@ var testemComponent = fluid.testem.instrumentation({
         "Firefox": [
             "--no-remote",
             "--headless"
-        ],
-        // Required to get Chromium working on GitHub CI.
-        "Chromium": "{that}.options.browserArgs.Chrome"
+        ]
     },
     testemOptions: {
         // Disable Headless Chrome we can figure out a solution to this issue: https://issues.fluid.net/browse/fluid-4064
         // Running Testem with the HEADLESS environment variable still works, and still runs headless.
-        skip: "PhantomJS,Safari,IE,Headless Chrome"
+        skip: "PhantomJS,Safari,IE,Headless Chrome,Chromium"
     },
     components: {
         express: {

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -42,7 +42,9 @@ var testemComponent = fluid.testem.instrumentation({
         "Firefox": [
             "--no-remote",
             "--headless"
-        ]
+        ],
+        // Required to get Chromium working on GitHub CI.
+        "Chromium": "{that}.options.browserArgs.Chrome"
     },
     testemOptions: {
         // Disable Headless Chrome we can figure out a solution to this issue: https://issues.fluid.net/browse/fluid-4064


### PR DESCRIPTION
See #35 for details.  Should be merged after the `fluid-express` and `fluid-handlebars` pulls so we can use non-dev releases.